### PR TITLE
Improved Code Review

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,7 +1,12 @@
-- books.effects.ts contains a godline. Likely could be broken up into multiple methods
+### Code Smells ###
+- books.effects.ts contains a godline. 
+	- Likely could be broken up into multiple methods
 - reading-list.effects.ts contains many long methods and godlines
 - total-count.component.ts is one of many lazy classes
+- State is contained within the reducer file.
+	- State should be self-contained
+	- Including it with the reducer muddies the distinct hierarchy of NgRx
 
-###Lighthouse###
+### Lighthouse ###
 - Buttons do not have an accessible name (search button)
 - Background and foreground colors do not have a sufficient contrast ratio. ('Reading List' and recommnended search)


### PR DESCRIPTION
Reviewed Code & Fixed Accessibility Issues
- Adjust font contrast over background for accessibility

Lint:
TSLint's support is discontinued and we're deprecating its support in Angular CLI.
To opt-in using the community driven ESLint builder, see: https://github.com/angular-eslint/angular-eslint#migrating-from-codelyzer-and-tslint.
Linting "okreads-browser"...
C:/Users/david/Desktop/Infosys Puzzle/web-ui-developer-puzzle-master/apps/okreads/browser/src/app/app.component.spec.ts:8:14
WARNING: 8:14  deprecation  async is deprecated: use `waitForAsync()`, (expected removal in v12)

Lint warnings found in the listed files.
TSLint's support is discontinued and we're deprecating its support in Angular CLI.
To opt-in using the community driven ESLint builder, see: https://github.com/angular-eslint/angular-eslint#migrating-from-codelyzer-and-tslint.
Linting "okreads-api"...
All files pass linting.
TSLint's support is discontinued and we're deprecating its support in Angular CLI.
To opt-in using the community driven ESLint builder, see: https://github.com/angular-eslint/angular-eslint#migrating-from-codelyzer-and-tslint.
Linting "shared-models"...
All files pass linting.
TSLint's support is discontinued and we're deprecating its support in Angular CLI.
To opt-in using the community driven ESLint builder, see: https://github.com/angular-eslint/angular-eslint#migrating-from-codelyzer-and-tslint.
Linting "books-feature"...
C:/Users/david/Desktop/Infosys Puzzle/web-ui-developer-puzzle-master/libs/books/feature/src/lib/book-search/book-search.component.spec.ts:12:14
WARNING: 12:14  deprecation  async is deprecated: use `waitForAsync()`, (expected removal in v12)

C:/Users/david/Desktop/Infosys Puzzle/web-ui-developer-puzzle-master/libs/books/feature/src/lib/books-feature.module.spec.ts:5:14
WARNING: 5:14   deprecation  async is deprecated: use `waitForAsync()`, (expected removal in v12)

C:/Users/david/Desktop/Infosys Puzzle/web-ui-developer-puzzle-master/libs/books/feature/src/lib/reading-list/reading-list.component.spec.ts:11:14
WARNING: 11:14  deprecation  async is deprecated: use `waitForAsync()`, (expected removal in v12)

C:/Users/david/Desktop/Infosys Puzzle/web-ui-developer-puzzle-master/libs/books/feature/src/lib/total-count/total-count.component.spec.ts:11:14
WARNING: 11:14  deprecation  async is deprecated: use `waitForAsync()`, (expected removal in v12)

Lint warnings found in the listed files.
TSLint's support is discontinued and we're deprecating its support in Angular CLI.
To opt-in using the community driven ESLint builder, see: https://github.com/angular-eslint/angular-eslint#migrating-from-codelyzer-and-tslint.
Linting "books-data-access"...
C:/Users/david/Desktop/Infosys Puzzle/web-ui-developer-puzzle-master/libs/books/data-access/src/lib/books-data-access.module.spec.ts:5:14
WARNING: 5:14  deprecation  async is deprecated: use `waitForAsync()`, (expected removal in v12)

Lint warnings found in the listed files.
TSLint's support is discontinued and we're deprecating its support in Angular CLI.
To opt-in using the community driven ESLint builder, see: https://github.com/angular-eslint/angular-eslint#migrating-from-codelyzer-and-tslint.
Linting "okreads-e2e"...
All files pass linting.
TSLint's support is discontinued and we're deprecating its support in Angular CLI.
To opt-in using the community driven ESLint builder, see: https://github.com/angular-eslint/angular-eslint#migrating-from-codelyzer-and-tslint.
Linting "shared-storage"...
All files pass linting.
TSLint's support is discontinued and we're deprecating its support in Angular CLI.
To opt-in using the community driven ESLint builder, see: https://github.com/angular-eslint/angular-eslint#migrating-from-codelyzer-and-tslint.
Linting "shared-testing"...
All files pass linting.
TSLint's support is discontinued and we're deprecating its support in Angular CLI.
To opt-in using the community driven ESLint builder, see: https://github.com/angular-eslint/angular-eslint#migrating-from-codelyzer-and-tslint.
Linting "api-books"...
All files pass linting.